### PR TITLE
if messageContent is empty, use msgID as file name

### DIFF
--- a/media/media.js
+++ b/media/media.js
@@ -17,7 +17,7 @@ const mediaHandler = async (url, incomingNumber, formattedMessage, msgID) => {
   });
   //If there is attachment on incoming message, get URL from attachment array
   //Create a file path and save to fileLocation variable
-  const fileLocation = path.resolve(__dirname, formattedMessage);
+  const fileLocation = path.resolve(__dirname, formattedMessage ? formattedMessage : msgID);
 
   //Download attachment to fileLocation using attachment URL
   try {
@@ -39,7 +39,7 @@ const mediaHandler = async (url, incomingNumber, formattedMessage, msgID) => {
 
     const params = {
       Bucket: "assistext",
-      Key: `attachments/${incomingNumber}/${formattedMessage}.png`,
+      Key: `attachments/${incomingNumber}/${formattedMessage ? formattedMessage : msgID}.png`,
       Body: fileStream,
       ACL: "private",
       Metadata: {


### PR DESCRIPTION
Prevent app from crashing if an attachment is sent with no message, since media.js uses message content to name file in S3 bucket/Digital Ocean Spaces.

Use ternary operator to name file as message body if provided and use msgID if messageContent is empty.