### PR TITLE
require .env compatible with ubuntu server

### DIFF
--- a/assistext.js
+++ b/assistext.js
@@ -2,7 +2,7 @@ const receive = require("./receive/receive");
 const express = require("express");
 const app = express();
 
-require("dotenv").config();
+require("dotenv").config({path: __dirname + '/.env'});
 
 app.use("/", receive);
 

--- a/receive/receive.js
+++ b/receive/receive.js
@@ -3,7 +3,6 @@ const bodyParser = require("body-parser");
 const Telnyx = require("telnyx");
 const send = require("../send/send");
 const mediaHandler = require("../media/media");
-require("dotenv").config();
 
 const receive = express();
 receive.use(bodyParser.json());

--- a/send/send.js
+++ b/send/send.js
@@ -3,9 +3,11 @@ const OpenAI = require("openai");
 const mediaHandler = require("../media/media");
 require("dotenv").config();
 
-const apiKey = process.env.TELNYX_API_KEY;
-const telnyx = Telnyx(apiKey);
-const openai = new OpenAI(process.env.OPENAI_API_KEY);
+const telnyxApiKey = process.env.TELNYX_API_KEY;
+const openAiApiKey = process.env.OPENAI_API_KEY;
+
+const telnyx = Telnyx(telnyxApiKey);
+const openai = new OpenAI(openAiApiKey);
 
 let send = async (
   incomingNumber,


### PR DESCRIPTION
Use new require syntax that allows .env variables to be available on production server.